### PR TITLE
Ejemplo versión C++: parar en caso de error de cin

### DIFF
--- a/PWClienteEjemplo.cpp
+++ b/PWClienteEjemplo.cpp
@@ -42,7 +42,7 @@ int main(){
   }
 
   bool game_on = true;
-  while(game_on){
+  while(game_on && cin.good()){
     getline(cin, buferRecepcion);
     if(buferRecepcion == "GAME OVER"){
       game_on = false;


### PR DESCRIPTION
Sin esto, en caso de que se cierre prematuramente el servidor, el ejemplo en versión C++ se queda funcionando hasta que aparece un error, o al menos eso pasa en Windows. Con esto se cierra inmediatamente en tal caso.